### PR TITLE
[skk] make config file "rule" to work

### DIFF
--- a/src/skk.c
+++ b/src/skk.c
@@ -482,11 +482,6 @@ FcitxSkkCreate(FcitxInstance *instance)
     };
     skk_context_set_auto_start_henkan_keywords(skk->context, AUTO_START_HENKAN_KEYWORDS, G_N_ELEMENTS(AUTO_START_HENKAN_KEYWORDS));
 
-    SkkRule* rule = skk_rule_new("default", NULL);
-    if (rule) {
-        skk_context_set_typing_rule(skk->context, rule);
-    }
-
     FcitxIMEventHook hk;
     hk.arg = skk;
     hk.func = FcitxSkkResetHook;


### PR DESCRIPTION
# BUG DESCRIPTION

skk_context_set_typing_rule call was called twice (duplicated).
First call get rule name from config file "rule" and set the rule.
And second call sets "default" rule (hardcoded).
In the result, rule is overwritten by default rule.
So, I removed second call.
