### PR TITLE
Update readme for fcitx5 and qt5 libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ __pycache__/
 *.pyc
 *.pya
 *.fdb_latexmk
+CMakeFiles
+Makefile
+CMakeCache.*
+*cmake_cache*
+cmake_install.cmake
+cmake-build-*

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ fcitx-skk is an input method engine for Fcitx, which uses libskk as its backend.
 Please install this packages before build this Program.
 
  - libskk-dev
- - libqt4-dev
- - fcitx-libs-dev
+ - qtbase5-dev
+ - libfcitx-qt5-dev
  - skkdic
 
-    $ sudo aptitude install libskk-dev libqt4-dev fcitx-libs-dev skkdic
+    $ sudo aptitude install libskk-dev qtbase5-dev libfcitx-qt5-dev skkdic
 
 
 ## Build dependency:


### PR DESCRIPTION
README was outdated.
Here are the new package names.
https://packages.ubuntu.com/search?searchon=contents&keywords=FcitxQt5WidgetsAddonsConfig.cmake&mode=exactfilename&suite=bionic&arch=any
https://packages.ubuntu.com/search?searchon=contents&keywords=Qt5Config.cmake&mode=exactfilename&suite=bionic&arch=any
